### PR TITLE
Scale button text based on device size

### DIFF
--- a/styles/inline.css
+++ b/styles/inline.css
@@ -32,10 +32,11 @@
   bottom: 0;
   left: 0;
 }
+
 .errorButton {
   height: 100%;
   width: 100%;
-  font-size: 500%;
+  font-size: 11vmin;
   font-weight: bold;
 }
 .green-colorScheme {


### PR DESCRIPTION
Use 11 % of the smallest viewport dimension as the font size.